### PR TITLE
Add Benchmark (pulse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ In the `Dashboards` section you should be able to find the `SSV Operational` das
 
 ## Benchmarking tool
 The Stack comes with a benchmarking tool which is [ssv-pulse](https://github.com/ssvlabs/ssv-pulse).
-It helps with troubleshooting and the results can be interpeted with our [Troubleshooting page](https://docs.ssv.network/operators/operator-node/maintenance/troubleshooting/#checklists-for-troubleshooting).
-
+It helps with troubleshooting and the results can be interpreted with our [Troubleshooting page](https://docs.ssv.network/operators/operator-node/maintenance/troubleshooting/#checklists-for-troubleshooting).
 To run the tool:
 * Edit `docker-compose.yaml`, at the very end of the file
 * Change `--consensus-addr` to your Consensus HTTP and `--execution-addr` to Execution HTTP

--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ Open your browser and go to [http://localhost:3000](http://localhost:3000) and l
 In the `Dashboards` section you should be able to find the `SSV Operational` dashboard. Unless the node is registered with the SSV network and has validators, some of the dashboard's columns might be empty.
 
 **WARNING**: Grafana and Prometheus is running only on the `localhost` by default. You should change the password and/or restrict access to it. If you expose Grafana and Prometheus to the internet, you should be extra careful and make sure they are secured.
+
+## Benchmarking tool
+The Stack comes with a benchmarking tool which is [ssv-pulse](https://github.com/ssvlabs/ssv-pulse).
+It helps with troubleshooting and the results can be interpeted with our [Troubleshooting page](https://docs.ssv.network/operators/operator-node/maintenance/troubleshooting/#checklists-for-troubleshooting).
+
+To run the tool:
+* Edit `docker-compose.yaml`, at the very end of the file
+* Change `--consensus-addr` to your Consensus HTTP and `--execution-addr` to Execution HTTP
+* If running on Hoodi - uncomment `--network=hoodi`
+* Run `docker compose run ssv-pulse`
+* The tool will be running for 60 minutes and produce a table with results

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -133,7 +133,7 @@ services:
       # - '--network=hoodi' # Add this if you run a Hoodi Node
       # - '--platform linux/arm64' # Add this if you run on an arm64 machine
     networks:
-      - local-network
+      - local-docker
     pull_policy: always
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,6 +118,24 @@ services:
     depends_on:
       - prometheus
 
+# Benchmark tool
+# To run: edit command below and start with docker compose run ssv-pulse
+# The tool will run for 60 minutes by default
+  ssv-pulse:
+    profiles: ["ssv-pulse"]
+    image: ghcr.io/ssvlabs/ssv-pulse:latest
+    command: 
+      - 'benchmark'
+      - '--consensus-addr=<YOUR_ADDRESS_HERE>' # Change to Consensus Node's address, e.g. http://127.0.0.1:5052
+      - '--execution-addr=<YOUR_ADDRESS_HERE>' # Change to Execution Node's address, e.g. http://127.0.0.1:8545
+      - '--ssv-addr=http://ssv-stack-ssv-node-1:16000'
+      - '--duration=60m'
+      # - '--network=hoodi' # Add this if you run a Hoodi Node
+      # - '--platform linux/arm64' # Add this if you run on an arm64 machine
+    networks:
+      - local-network
+    pull_policy: always
+
 networks:
   local-docker:
     driver: bridge


### PR DESCRIPTION
- Added ssv-pulse to `docker-compose.yaml` with `ssv-pulse` profile so it doesn't run by default
- Updated README with instructions on how to run it + link to docs to interpret results