### PR TITLE
Prometheus datasource to lowercase

### DIFF
--- a/grafana/datasources/prometheus.yml
+++ b/grafana/datasources/prometheus.yml
@@ -1,7 +1,7 @@
 apiVersion: 1
 datasources:
-  - name: Prometheus
-    uid: Prometheus
+  - name: prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090


### PR DESCRIPTION
Matching our OTel operational dashboard. There the data source is used in lowercase:
```
"type": "prometheus",
"uid": "prometheus"
```